### PR TITLE
Add step to contact API to revoke JWT token on logout

### DIFF
--- a/src/api/actions/Api.ts
+++ b/src/api/actions/Api.ts
@@ -1,8 +1,7 @@
 import * as HttpStatus from "http-status-codes";
-import { push } from "react-router-redux";
 import { Dispatch } from "redux";
 import { ThunkAction } from "redux-thunk";
-import { completeLogout } from "../../auth/actions";
+import { completeLogoutAndRedirect } from "../../auth/actions/index";
 import { IAuthState } from "../../auth/model/AuthenticationState";
 
 export declare type ApiSuccessCallback<T> = (dispatch: Dispatch<IAuthState>, response: T) => void;
@@ -110,17 +109,19 @@ export class Api {
     return this.requestWithPayload(pathname, payload, "PUT", dispatch, token);
   }
 
+  protected deleteRequest(pathname: string, dispatch: Dispatch<IAuthState>, token: string): Promise<any> {
+    return this.request(pathname, dispatch, token, {
+      method: "DELETE",
+    });
+  }
+
   protected handleApiResponse<T>(dispatch: Dispatch<IAuthState>, response: Response): Promise<T | string> {
     switch (response.status) {
       case HttpStatus.OK:
       case HttpStatus.CREATED:
         return response.json();
       case HttpStatus.UNAUTHORIZED:
-        dispatch(completeLogout());
-        dispatch(push("/auth/login", {
-          // TODO: This path should be configurable and not constant.
-          redirectPath: "/app",
-        }));
+        dispatch(completeLogoutAndRedirect());
         return Promise.reject("You are not logged in.");
       case HttpStatus.BAD_REQUEST:
         return response.json().then(this.errorTransformer.bind(this, response.url));

--- a/src/auth/actions/AuthApi.ts
+++ b/src/auth/actions/AuthApi.ts
@@ -3,109 +3,128 @@ import { Dispatch } from "redux";
 
 import { Api } from "../../api/actions";
 import { IJwtUserResponse, IUser } from "../../app/types";
-import { IApiError } from "../../index";
+import { completeLogoutAndRedirect, IApiError } from "../../index";
 import { IAuthState } from "../model/AuthenticationState";
 import { completeLogin, failLogin, startLogin, successfulGetUserDetails } from "./index";
 
 export class AuthApi extends Api {
-    public static getInstance(): AuthApi {
-      if (!AuthApi.singleton) {
-        AuthApi.singleton = new AuthApi();
-      }
-
-      return AuthApi.singleton;
+  public static getInstance(): AuthApi {
+    if (!AuthApi.singleton) {
+      AuthApi.singleton = new AuthApi();
     }
 
-    private static singleton: AuthApi;
+    return AuthApi.singleton;
+  }
 
-    private static userFromJwtUserResponse(response: IJwtUserResponse): IUser {
-      return {
-        id: response.id,
-        username: response.username,
-        email: response.email,
-        firstName: response.first_name,
-        lastName: response.last_name,
-      };
-    }
+  private static singleton: AuthApi;
 
-    public login(username: string, password: string) {
-      return (dispatch: Dispatch<IAuthState>, getState: () => IAuthState) => {
-        dispatch(startLogin());
-        const authState = getState().auth;
-        const innerPayload = authState.useEmailAsUsername
-          ? { email: username, password }
-          : { username, password };
+  private static userFromJwtUserResponse(response: IJwtUserResponse): IUser {
+    return {
+      id: response.id,
+      username: response.username,
+      email: response.email,
+      firstName: response.first_name,
+      lastName: response.last_name,
+    };
+  }
 
-        // Some auth systems expect parameters in the form:
-        // {
-        //   user: {
-        //     email: test@test.com
-        //     password: testtest
-        //   }
-        // }
-        const payload = getState().auth.wrapParameters
-          ? { user: innerPayload }
-          : innerPayload;
-        return this.postRequest("/api/login/username/jwt/", payload, dispatch, null)
-          .then((response: IJwtUserResponse) => {
-            if (response) {
-              if (response.token) {
-                dispatch(completeLogin(response.token));
-              }
-              if (response.email) {
-                const user = AuthApi.userFromJwtUserResponse(response);
-                dispatch(successfulGetUserDetails(user));
-              } else {
-                // TODO: Should really fix the Django server so that it returns the user details
-                // with the tokens--that would allow elimination of this branching code path.
-                // Have to grab new state because we've just updated through dispatch, in theory
-                const token = getState().auth.token;
-                return this.getRequest("/api/users/me/", dispatch, token)
-                .then((userDetailsResponse: IUser) => {
-                  dispatch(successfulGetUserDetails(userDetailsResponse));
-                });
-              }
+  public login(username: string, password: string) {
+    return (dispatch: Dispatch<IAuthState>, getState: () => IAuthState) => {
+      dispatch(startLogin());
+      const authState = getState().auth;
+      const innerPayload = authState.useEmailAsUsername
+        ? { email: username, password }
+        : { username, password };
+
+      // Some auth systems expect parameters in the form:
+      // {
+      //   user: {
+      //     email: test@test.com
+      //     password: testtest
+      //   }
+      // }
+      const payload = getState().auth.wrapParameters
+        ? { user: innerPayload }
+        : innerPayload;
+      return this.postRequest("/api/login/username/jwt/", payload, dispatch, null)
+        .then((response: IJwtUserResponse) => {
+          if (response) {
+            if (response.token) {
+              dispatch(completeLogin(response.token));
             }
-          });
+            if (response.email) {
+              const user = AuthApi.userFromJwtUserResponse(response);
+              dispatch(successfulGetUserDetails(user));
+            } else {
+              // TODO: Should really fix the Django server so that it returns the user details
+              // with the tokens--that would allow elimination of this branching code path.
+              // Have to grab new state because we've just updated through dispatch, in theory
+              const token = getState().auth.token;
+              return this.getRequest("/api/users/me/", dispatch, token)
+              .then((userDetailsResponse: IUser) => {
+                dispatch(successfulGetUserDetails(userDetailsResponse));
+              });
+            }
+          }
+        });
+    };
+  }
+
+  public socialLogin(provider: string, code: string, redirectUri: string) {
+    return (dispatch: Dispatch<IAuthState>, getState: () => IAuthState) => {
+      dispatch(startLogin());
+      const payload = {
+        provider,
+        code,
+        redirect_uri: redirectUri,
       };
-    }
+      return this.postRequest("/api/login/social/jwt_user/", payload, dispatch, getState().auth.token)
+        .then((response: IJwtUserResponse) => {
+          const user = AuthApi.userFromJwtUserResponse(response);
+          dispatch(completeLogin(response.token));
+          dispatch(successfulGetUserDetails(user));
+        });
+    };
+  }
 
-    public socialLogin(provider: string, code: string, redirectUri: string) {
-      return (dispatch: Dispatch<IAuthState>, getState: () => IAuthState) => {
-        dispatch(startLogin());
-        const payload = {
-          provider,
-          code,
-          redirect_uri: redirectUri,
-        };
-        return this.postRequest("/api/login/social/jwt_user/", payload, dispatch, getState().auth.token)
-          .then((response: IJwtUserResponse) => {
-            const user = AuthApi.userFromJwtUserResponse(response);
-            dispatch(completeLogin(response.token));
-            dispatch(successfulGetUserDetails(user));
-          });
-      };
-    }
+  public logout() {
+    return (dispatch: Dispatch<IAuthState>, getState: () => IAuthState) => {
+      const token = getState().auth.token;
+      return this.deleteRequest("/api/logout/jwt/", dispatch, token)
+      .then(() => {
+        dispatch(completeLogoutAndRedirect());
+      });
+    };
+  }
 
-    protected errorTransformer(_url: string, _error: IApiError): Promise<string> {
-      return Promise.reject("Invalid credentials.");
-    }
+  protected errorTransformer(_url: string, _error: IApiError): Promise<string> {
+    return Promise.reject("Invalid credentials.");
+  }
 
-    protected handleUnsuccessfulRequest(reason: string, dispatch: Dispatch<IAuthState>) {
-      super.handleUnsuccessfulRequest(reason, dispatch);
-      dispatch(failLogin(reason));
-    }
+  protected handleUnsuccessfulRequest(reason: string, dispatch: Dispatch<IAuthState>) {
+    super.handleUnsuccessfulRequest(reason, dispatch);
+    dispatch(failLogin(reason));
+  }
 
-    protected handleApiResponse<T>(dispatch: Dispatch<IAuthState>, response: Response): Promise<T | string> {
-      if (response.status === HttpStatus.OK || response.status === HttpStatus.CREATED) {
+  protected handleApiResponse<T>(dispatch: Dispatch<IAuthState>, response: Response): Promise<T | string> {
+    switch (response.status) {
+      case HttpStatus.OK:
+      case HttpStatus.CREATED:
         // Handle pulling the JWT token out of the headers if it appears there.
         const authorizationHeader = response.headers.get("Authorization");
         if (authorizationHeader !== null) {
           const token = authorizationHeader.split(" ")[1];
           dispatch(completeLogin(token));
         }
-      }
-
-      return super.handleApiResponse(dispatch, response);
+        return super.handleApiResponse(dispatch, response);
+      case HttpStatus.NO_CONTENT:
+        return Promise.resolve("Successfully logged out.");
+      case HttpStatus.UNAUTHORIZED:
+        return Promise.reject("Invalid credentials.");
+      default:
+        super.handleApiResponse(dispatch, response);
     }
+
+    return super.handleApiResponse(dispatch, response);
   }
+}

--- a/src/auth/actions/index.ts
+++ b/src/auth/actions/index.ts
@@ -1,7 +1,10 @@
-import { Action } from "redux";
+import { push } from "react-router-redux";
+import { Action, Dispatch } from "redux";
 // This import will remap the typing for Dispatch so it's more tolerant of passing functions
 import "redux-thunk";
+
 import { IUser } from "../../app/types/index";
+import { IAuthState } from "../model/AuthenticationState";
 
 const typeCache: { [label: string]: boolean } = {};
 
@@ -34,6 +37,19 @@ export function startLogin() {
 
 export interface ICompleteLogin extends Action {
   token: string;
+}
+
+// Performs the deletion of the JWT token before redirecting the user back out to the login page.
+// NOTE: In almost all cases you want AuthApi.getInstance().logout() instead. That method also
+// handles hitting the API backend to revoke the JWT token as an extra precaution.
+export function completeLogoutAndRedirect() {
+  return (dispatch: Dispatch<IAuthState>, getState: () => IAuthState) => {
+    dispatch(completeLogout());
+    dispatch(push("/auth/login", {
+      // TODO: This path should be configurable.
+      redirectPath: "/app",
+    }));
+  };
 }
 
 // TODO: rest-social-auth documentation doesn't reference a token expiration parameter, but I should find and set one

--- a/src/auth/pages/LogoutPage.tsx
+++ b/src/auth/pages/LogoutPage.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { Dispatch } from "redux";
-import { completeLogout } from "../actions/index";
+import { AuthApi } from "../actions/AuthApi";
 import { IAuthState } from "../model/AuthenticationState";
 
 export interface ILogoutPageDispatchProps {
@@ -28,7 +28,7 @@ class LogoutPage extends React.Component<ILogoutPageProps, {}> {
 function mapDispatchToProps(dispatch: Dispatch<IAuthState>, ownProps: ILogoutPageOwnProps): ILogoutPageDispatchProps {
   return {
     onLogout: () => {
-      dispatch(completeLogout());
+      dispatch(AuthApi.getInstance().logout());
       const redirectUri = ownProps.redirectUri ? ownProps.redirectUri : "/";
       ownProps.history.replace(redirectUri);
     },


### PR DESCRIPTION
Also snuck in a change making the message on an unsuccessful login attempt "Invalid credentials." instead of "You are not logged in." since the latter was obvious and kind of confusing.